### PR TITLE
force app subdomain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pkg/*
 .powder
 tmp
 bin
+.idea


### PR DESCRIPTION
"In March, we're making a security update to your app settings that will invalidate calls from URIs not listed in the Valid OAuth redirect URIs field"